### PR TITLE
CI: [V2:21] Add Repo Manifest for ERCs

### DIFF
--- a/Build.toml
+++ b/Build.toml
@@ -1,0 +1,13 @@
+name = "ERCs"
+
+[locations.ERCs]
+repository = "https://github.com/eips-wg/ERCs.git"
+base-url = "https://eips-wg.github.io/ERCs/"
+
+[locations.EIPs]
+repository = "https://github.com/eips-wg/EIPs.git"
+base-url = "https://eips-wg.github.io/EIPs/"
+
+[theme]
+repository = "https://github.com/eips-wg/theme.git"
+commit = "0ddac35da36d311a8401c6cfb79c9991f78b647d"


### PR DESCRIPTION
> Part of [V2: Multi-repo local build system](https://github.com/eips-wg/preprocessor/issues/15).

## Description

Adds a tracked `Build.toml` manifest so this proposal repo declares its own identity, related proposal repos, canonical base URLs, and theme pin.